### PR TITLE
Encrypter::decrypt: re-throw exceptions from openssl_decrypt as Decry…

### DIFF
--- a/src/Tomgrohl/Laravel/Encryption/Encrypter.php
+++ b/src/Tomgrohl/Laravel/Encryption/Encrypter.php
@@ -106,9 +106,14 @@ class Encrypter extends BaseEncrypter
         // Here we will decrypt the value. If we are able to successfully decrypt it
         // we will then unserialize it and return it out to the caller. If we are
         // unable to decrypt this value we will throw out an exception message.
-        $decrypted = \openssl_decrypt(
-            $payload['value'], $this->cipher, $this->key, 0, $iv
-        );
+        try {
+            $decrypted = \openssl_decrypt(
+                $payload['value'], $this->cipher, $this->key, 0, $iv
+            );
+        } catch (\Exception $e) {
+            // Pass exceptions through as DecryptExceptions so they're handled properly
+            throw new DecryptException($e->getMessage());
+        }
 
         if ($decrypted === false) {
             throw new DecryptException('Could not decrypt the data.');


### PR DESCRIPTION
I ran into the same thing.  openssl_decrypt can throw other exception types that bubble up and cause problems.

In my case, this was when laravel tried to decrypt an old cookie with an embedded IV that was no longer valid.  That should just result in the cookie being discarded, not crash the application.